### PR TITLE
Support dailymail.co.uk articles

### DIFF
--- a/data/SpeedReaderConfig.json
+++ b/data/SpeedReaderConfig.json
@@ -1,5 +1,26 @@
 [
     {
+        "domain": "dailymail.co.uk",
+        "url_rules": [
+            "||dailymail.co.uk/*/article-*/*"
+        ],
+        "declarative_rewrite": {
+            "main_content": [
+                "#js-article-text > h2",
+                "#js-article-text > ul",
+                "#js-article-text > [class*=byline]",
+                "#js-article-text > [itemprop=articleBody]"
+            ],
+            "main_content_cleanup": [
+                "[data-track-module$=related_carousel]"
+            ],
+            "delazify": true,
+            "fix_embeds": true,
+            "content_script": null,
+            "preprocess": []
+        }
+    },
+    {
         "domain": "chron.com",
         "url_rules": [
             "||chron.com/*/article/"

--- a/data/content-stylesheet.css
+++ b/data/content-stylesheet.css
@@ -388,8 +388,12 @@ article sup, article sub {
     padding-bottom: 45px;
   }
   article video {
+    width: 100%;
     height: auto;
     position: relative;
+  }
+  #article .mol-video {
+    margin: 1.2em auto;
   }
 }
 


### PR DESCRIPTION
Adds initial support for dailymail.co.uk articles, as well as sizes video elements to 100% the width of the parent container, and gives them a top/bottom margin.

Closes #9 

![Before and after](https://user-images.githubusercontent.com/815158/89619954-80530b80-d854-11ea-91e7-2c1f10856afb.png)
