### PR TITLE
Remove site-specific selector

### DIFF
--- a/data/content-stylesheet.css
+++ b/data/content-stylesheet.css
@@ -391,8 +391,6 @@ article sup, article sub {
     width: 100%;
     height: auto;
     position: relative;
-  }
-  #article .mol-video {
     margin: 1.2em auto;
   }
 }


### PR DESCRIPTION
The `.mol-video` selector is not needed. Instead, the margin should be applied to all video elements, on all domains.