### PR TITLE
Initial support for ForeignPolicy.com

### DIFF
--- a/data/SpeedReaderConfig.json
+++ b/data/SpeedReaderConfig.json
@@ -1,5 +1,26 @@
 [
     {
+        "domain": "foreignpolicy.com",
+        "url_rules": [
+            "/foreignpolicy.com\/\\d{4}\/\\d{2}\/\\d{2}\/.*/"
+        ],
+        "declarative_rewrite": {
+            "main_content": [
+                "article"
+            ],
+            "main_content_cleanup": [
+                "[class*=taboola]",
+                ".the-comments",
+                ".the-tags",
+                "[class*=related-articles]"
+            ],
+            "delazify": true,
+            "fix_embeds": true,
+            "content_script": null,
+            "preprocess": []
+        }
+    },
+    {
         "domain": "dailymail.co.uk",
         "url_rules": [
             "||dailymail.co.uk/*/article-*/*"


### PR DESCRIPTION
This domain/property appears to be pretty straight-forward—it appears to be running atop WordPress. As such, it was very straight-forward to add good, initial support. Early tests look positive too.

Test URLs:

- https://foreignpolicy.com/2020/08/07/brent-scowcroft-national-security-council-dies-bush-foreign-policy/
- https://foreignpolicy.com/2020/08/05/beirut-explosion-blast-lebanon-ammonium-nitrate-chernobyl-corruption/
- https://foreignpolicy.com/2020/08/07/belarus-election-protests-lukashenko-europe/
- https://foreignpolicy.com/2020/08/07/trump-ban-tiktok-wechat-china-apps/

![image](https://user-images.githubusercontent.com/815158/89716533-5b08ef00-d973-11ea-819a-5528e6fe5aac.png)