### PR TITLE
Updating selectors to match new site-structure

### DIFF
--- a/data/SpeedReaderConfig.json
+++ b/data/SpeedReaderConfig.json
@@ -312,33 +312,24 @@
         ],
         "declarative_rewrite": {
             "main_content": [
-                "article header",
-                ".content__article-body"
+                "a[data-component=series]",
+                "a[data-component=section]",
+                "div[role=textbox]",
+                "h1",
+                "a[rel=author]",
+                "picture",
+                "#the-caption figcaption",
+                "main .article-body-commercial-selector",
+                "aside",
+                "p"
             ],
             "main_content_cleanup": [
-                ".hide-on-mobile",
-                ".inline-icon",
-                ".atom__button",
-                "input",
-                ".meta__extras",
-                ".content__headline-showcase-wrapper",
-                ".fc-container__header",
-                "figure.element-embed",
-                ".vjs-control-text"
+                "aside > span"
             ],
             "delazify": true,
             "fix_embeds": true,
-            "content_script": "<script>\n [...document.querySelectorAll(\"[data-src-background]\")]\n .map(d => d.src = d.dataset[\"src-background\"].replace(\"background-image: url\", \"\").replace(/[\\(\\)]/g, \"\"))\n </script>",
-            "preprocess": [
-                {
-                    "selector": ".vjs-big-play-button[style]",
-                    "attribute": [
-                        "style",
-                        "data-src-background"
-                    ],
-                    "element_name": "img"
-                }
-            ]
+            "content_script": "<style>blockquote { font-size: 1.2em; line-height: 1.5em } #article aside { float: left; margin: 1em; max-width: 40% } aside::before { content: '“'; display: block; height: .25em; font-size: 4em } figcaption svg {display: inline-block; margin-right: .25em } [rel=author] { display: block; margin-bottom: 1em } [data-component=series], [data-component=section] { display: inline-block; margin-right: 1em } #article figcaption { max-width: 75%; text-align: center; margin: 1em auto }</style>",
+            "preprocess": []
         }
     },
     {

--- a/data/SpeedReaderConfig.json
+++ b/data/SpeedReaderConfig.json
@@ -329,7 +329,7 @@
             ],
             "delazify": true,
             "fix_embeds": true,
-            "content_script": "<style>blockquote { font-size: 1.2em; line-height: 1.5em } #article aside { float: left; margin: 1em; max-width: 40% } aside::before { content: '“'; display: block; height: .25em; font-size: 4em } figcaption svg {display: inline-block; margin-right: .25em } [rel=author] { display: block; margin-bottom: 1em } [data-component=series], [data-component=section] { display: inline-block; margin-right: 1em }</style>",
+            "content_script": "<style>blockquote { font-size: 1.2em; line-height: 1.5em } #article aside { float: left; margin: 1em; max-width: 40% } aside::before { content: '“'; display: block; height: .25em; font-size: 4em } figcaption svg {display: inline-block; margin-right: .25em } [data-component=series], [data-component=section] { display: inline-block; margin-right: 1em } li:empty { display: none }</style>",
             "preprocess": []
         }
     },

--- a/data/SpeedReaderConfig.json
+++ b/data/SpeedReaderConfig.json
@@ -314,6 +314,7 @@
             "main_content": [
                 "a[data-component=series]",
                 "a[data-component=section]",
+                "[data-component=meta-byline]",
                 "div[role=textbox]",
                 "h1",
                 "a[rel=author]",
@@ -328,7 +329,7 @@
             ],
             "delazify": true,
             "fix_embeds": true,
-            "content_script": "<style>blockquote { font-size: 1.2em; line-height: 1.5em } #article aside { float: left; margin: 1em; max-width: 40% } aside::before { content: '“'; display: block; height: .25em; font-size: 4em } figcaption svg {display: inline-block; margin-right: .25em } [rel=author] { display: block; margin-bottom: 1em } [data-component=series], [data-component=section] { display: inline-block; margin-right: 1em } #article figcaption { max-width: 75%; text-align: center; margin: 1em auto }</style>",
+            "content_script": "<style>blockquote { font-size: 1.2em; line-height: 1.5em } #article aside { float: left; margin: 1em; max-width: 40% } aside::before { content: '“'; display: block; height: .25em; font-size: 4em } figcaption svg {display: inline-block; margin-right: .25em } [rel=author] { display: block; margin-bottom: 1em } [data-component=series], [data-component=section] { display: inline-block; margin-right: 1em }</style>",
             "preprocess": []
         }
     },


### PR DESCRIPTION
The Guardian appears to have updated their site, invalidating (nearly?) all of our earlier rules.

![image](https://user-images.githubusercontent.com/815158/89743204-61c45e80-da66-11ea-8f24-5deb3cb1771c.png)
![image](https://user-images.githubusercontent.com/815158/89743274-1f4f5180-da67-11ea-8a54-f3c80dbde818.png)
