### PR TITLE
Updates selectors for theguardian.com

### DIFF
--- a/data/SpeedReaderConfig.json
+++ b/data/SpeedReaderConfig.json
@@ -350,7 +350,7 @@
             ],
             "delazify": true,
             "fix_embeds": true,
-            "content_script": "<style>blockquote { font-size: 1.2em; line-height: 1.5em } #article aside { float: left; margin: 1em; max-width: 40% } aside::before { content: '“'; display: block; height: .25em; font-size: 4em } figcaption svg {display: inline-block; margin-right: .25em } [data-component=series], [data-component=section] { display: inline-block; margin-right: 1em } li:empty { display: none }</style>",
+            "content_script": "<style>#article aside { float: left; margin: 1em; max-width: 40% } aside::before { content: '“'; display: block; height: .25em; font-size: 4em } figcaption svg {display: inline-block; margin-right: .25em } [data-component=series], [data-component=section] { display: inline-block; margin-right: 1em } li:empty { display: none }</style>",
             "preprocess": []
         }
     },

--- a/data/SpeedReaderConfig.json
+++ b/data/SpeedReaderConfig.json
@@ -312,33 +312,25 @@
         ],
         "declarative_rewrite": {
             "main_content": [
-                "article header",
-                ".content__article-body"
+                "a[data-component=series]",
+                "a[data-component=section]",
+                "[data-component=meta-byline]",
+                "div[role=textbox]",
+                "h1",
+                "a[rel=author]",
+                "picture",
+                "#the-caption figcaption",
+                "main .article-body-commercial-selector",
+                "aside",
+                "p"
             ],
             "main_content_cleanup": [
-                ".hide-on-mobile",
-                ".inline-icon",
-                ".atom__button",
-                "input",
-                ".meta__extras",
-                ".content__headline-showcase-wrapper",
-                ".fc-container__header",
-                "figure.element-embed",
-                ".vjs-control-text"
+                "aside > span"
             ],
             "delazify": true,
             "fix_embeds": true,
-            "content_script": "<script>\n [...document.querySelectorAll(\"[data-src-background]\")]\n .map(d => d.src = d.dataset[\"src-background\"].replace(\"background-image: url\", \"\").replace(/[\\(\\)]/g, \"\"))\n </script>",
-            "preprocess": [
-                {
-                    "selector": ".vjs-big-play-button[style]",
-                    "attribute": [
-                        "style",
-                        "data-src-background"
-                    ],
-                    "element_name": "img"
-                }
-            ]
+            "content_script": "<style>blockquote { font-size: 1.2em; line-height: 1.5em } #article aside { float: left; margin: 1em; max-width: 40% } aside::before { content: '“'; display: block; height: .25em; font-size: 4em } figcaption svg {display: inline-block; margin-right: .25em } [data-component=series], [data-component=section] { display: inline-block; margin-right: 1em } li:empty { display: none }</style>",
+            "preprocess": []
         }
     },
     {


### PR DESCRIPTION
It appears The Guardian changed their page-structure in a major way, invalidating (nearly?) all of our selectors.

![image](https://user-images.githubusercontent.com/815158/89743740-a43c6a00-da6b-11ea-8dde-7cab30de1b4e.png)