### PR TITLE
Fix subhead colors for dark mode

### DIFF
--- a/data/content-stylesheet.css
+++ b/data/content-stylesheet.css
@@ -37,7 +37,7 @@ p {
   font-size: 1.5em;
   line-height: 1em;
   font-weight: normal;
-  color: rgba(27, 27, 27, 0.65);
+  color: #495057;
 }
 
 .metadata {
@@ -465,5 +465,9 @@ iframe {
 
   a[href] {
     color: #737ADE;
+  }
+
+  .subhead, .subheading {
+    color: #C2C4CF;
   }
 }


### PR DESCRIPTION
In dark mode the subhead blends into the article because it's color is
not specified. Grabbed the correct colors from Figma.
![dark_mode_subhead_before](https://user-images.githubusercontent.com/28680078/115594579-be7d4780-a28a-11eb-8c30-661ec524ecff.png)
![dark_mode_subhead_after](https://user-images.githubusercontent.com/28680078/115594584-bfae7480-a28a-11eb-9e49-a870902d5567.png)

included before/after screenshots.
