### PR TITLE
Make article padding 72px. This on Figma

### DIFF
--- a/data/content-stylesheet.css
+++ b/data/content-stylesheet.css
@@ -370,7 +370,7 @@ article sup, article sub {
   #article {
     margin-left: auto;
     margin-right: auto;
-    padding-top: 35px;
+    padding-top: 4.5em;
     padding-bottom: 35px;
     position: relative;
     border-top: 1px solid rgba(0, 0, 0, 0.2);
@@ -381,7 +381,6 @@ article sup, article sub {
   #article {
     margin-top: 0;
     border-top: none;
-    padding-top: 32px;
   }
   #article:last-of-type {
     padding-bottom: 45px;


### PR DESCRIPTION
Resolves https://github.com/brave-experiments/SpeedReader/issues/31

I've included before + after pictures.

![Screenshot_20210825_140910](https://user-images.githubusercontent.com/28680078/130865373-a5181ca5-b43a-425a-aac5-39dd20b3e4b7.png)
![Screenshot_20210825_140831](https://user-images.githubusercontent.com/28680078/130865378-6425bd0a-c00d-489c-aec8-e96e9044c930.png)
